### PR TITLE
ci: update dashboard tag version format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,6 @@ jobs:
           git commit -m "Build embed files"
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
           git push origin statik
-          tag="v$(date -u +%Y.%m.%d)"
+          tag="v0.5.$(date -u +%Y%m%d)"
           git tag "$tag"
           git push origin "$tag"


### PR DESCRIPTION
## Summary

- Change generated Dashboard tags from `vYYYY.MM.DD` to `v0.5.YYYYMMDD`.

## Validation

- Parsed `.github/workflows/build.yml` as YAML.
- Verified the generated UTC tag for 2026-07-14 is `v0.5.20260714`.
