### PR TITLE
修复 Vue 3 下 Dashboard 弹窗交互与空配置报错

### DIFF
--- a/src/views/Advance.vue
+++ b/src/views/Advance.vue
@@ -124,11 +124,14 @@
               <d-list-group-item class="p-3">
                 <d-row>
                   <d-col sm="12" md="2">
-                    <d-button outline theme="danger" @click="handleClick">&nbsp;Purge
+                    <d-button outline theme="danger" @click.stop="handleClick">&nbsp;Purge
                       Database&nbsp;</d-button>
                     <d-modal v-if="showDialog" @close="handleClose" centered>
-                      <d-modal-header>
+                      <d-modal-header :close="false">
                         <d-modal-title>Are you absolutely sure?</d-modal-title>
+                        <button type="button" class="close" aria-label="Close" @click.stop.prevent="handleClose">
+                          <span aria-hidden="true">&times;</span>
+                        </button>
                       </d-modal-header>
                       <d-modal-body>
                         <label>This action <span style="color: red; font-weight: bold">cannot</span> be undone. This

--- a/src/views/Items.vue
+++ b/src/views/Items.vue
@@ -66,7 +66,7 @@
                       <d-button-group>
                         <d-button size="small" outline @click="view_item(item.ItemId)"><i
                           class="material-icons">visibility</i></d-button>
-                        <d-button size="small" theme="danger" outline @click="open_delete_item_dialog(item.ItemId)"><i
+                        <d-button size="small" theme="danger" outline @click.stop="open_delete_item_dialog(item.ItemId)"><i
                           class="material-icons">delete</i></d-button>
                       </d-button-group>
                     </td>
@@ -80,8 +80,11 @@
     </div>
 
     <d-modal v-if="showDialog" @close="showDialog = false" centered>
-      <d-modal-header>
+      <d-modal-header :close="false">
         <d-modal-title>Delete Item</d-modal-title>
+        <button type="button" class="close" aria-label="Close" @click.stop.prevent="showDialog = false">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </d-modal-header>
       <d-modal-body>
         <div class="mb-3">Are you sure to delete item <span style="font-weight: bold">{{ deleteItemId }}</span>? Please

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -74,7 +74,7 @@ export default {
         this.positiveFeedbackTypes = response.data.recommend.data_source.positive_feedback_types;
         this.cacheSize = response.data.database.cache_size;
         this.nonPersonalized = ['latest'];
-        response.data.recommend['non-personalized'].forEach((recommender) => {
+        (response.data.recommend['non-personalized'] || []).forEach((recommender) => {
           this.nonPersonalized.push(`non-personalized/${recommender.name}`);
         });
       });

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -58,7 +58,7 @@
                           class="material-icons">visibility</i></d-button>
                         <d-button size="small" outline @click="list_user_recommend(user.UserId)"><i
                           class="material-icons">favorite</i></d-button>
-                        <d-button size="small" theme="danger" outline @click="open_delete_user_dialog(user.UserId)"><i
+                        <d-button size="small" theme="danger" outline @click.stop="open_delete_user_dialog(user.UserId)"><i
                           class="material-icons">delete</i></d-button>
                       </d-button-group>
                     </td>
@@ -72,8 +72,11 @@
     </div>
 
     <d-modal v-if="showDialog" @close="showDialog = false" centered>
-      <d-modal-header>
-        <d-modal-title>Delete Item</d-modal-title>
+      <d-modal-header :close="false">
+        <d-modal-title>Delete User</d-modal-title>
+        <button type="button" class="close" aria-label="Close" @click.stop.prevent="showDialog = false">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </d-modal-header>
       <d-modal-body>
         <div class="mb-3">Are you sure to delete user <span style="font-weight: bold">{{ deleteUserId }}</span>? Please


### PR DESCRIPTION
## 变更说明

修复 Dashboard 迁移到 Vue 3 后的弹窗交互问题，并兼容未配置非个性化推荐器的场景。

## 问题原因

- 打开弹窗的点击事件会继续冒泡到 document，被 Shards Vue 的 click-away 监听器立即识别为弹窗外点击，导致弹窗刚挂载就关闭。
- Shards Vue 默认关闭按钮通过父组件触发 close 事件，在当前 Vue 3 组件层级下无法可靠关闭弹窗。
- Overview 直接对 recommend.non-personalized 调用 forEach；该配置为 null 时会触发运行时异常。

## 修复内容

- 为 Items、Users 和 Advance 的弹窗打开按钮增加 click.stop。
- 使用项目中 RecFlow 已采用的显式关闭按钮写法，替代失效的默认关闭按钮。
- 修正用户删除弹窗标题，将 Delete Item 改为 Delete User。
- 将空的 non-personalized 配置按空数组处理。

## 验证

- [x] 本地实际验证 Items 删除弹窗可以打开和关闭
- [x] 本地实际验证 Users 删除弹窗可以打开和关闭
- [x] 本地实际验证 Advance 清库确认弹窗可以打开和关闭
- [x] pnpm install --frozen-lockfile
- [x] pnpm lint
- [x] pnpm exec jest --runInBand
- [x] pnpm build
- [x] git diff --check

生产构建仅保留仓库现有的 Sass 弃用和资源体积警告，没有新增构建错误。